### PR TITLE
Add Emoji One as a preferred, not prepended, font

### DIFF
--- a/debian/fontconfig/56-emojione.conf
+++ b/debian/fontconfig/56-emojione.conf
@@ -1,44 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<!--
-Insert the Emoji One font as the first fallback after the
-core DejaVu fonts, but before the DejaVu extra fonts (which
-contain their own emoji implementation)
--->
 <fontconfig>
-  <match>
-    <test qual="any" name="family">
-        <string>serif</string>
-    </test>
-    <edit name="family" mode="prepend_first">
-      <string>DejaVu Serif</string>
-    </edit>
-    <edit name="family" mode="prepend_first">
-      <string>Emoji One</string>
-    </edit>
-  </match>
-
-  <match target="pattern">
-    <test qual="any" name="family">
-        <string>sans-serif</string>
-    </test>
-    <edit name="family" mode="prepend_first">
-      <string>DejaVu Sans</string>
-    </edit>
-    <edit name="family" mode="prepend_first">
-      <string>Emoji One</string>
-    </edit>
-  </match>
-
-  <match target="pattern">
-    <test qual="any" name="family">
-        <string>monospace</string>
-    </test>
-    <edit name="family" mode="prepend_first">
-      <string>DejaVu Sans Mono</string>
-    </edit>
-    <edit name="family" mode="prepend_first">
-      <string>Emoji One</string>
-    </edit>
-  </match>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Emoji One</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Emoji One</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Emoji One</family>
+    </prefer>
+  </alias>
 </fontconfig>


### PR DESCRIPTION
We had some rendering issues in Ubuntu Touch (https://github.com/ubports/ubuntu-touch/issues/423) caused by Emoji One being used as the default font in some situations. Using it as the "preferred" font rather than the default font should fix that problem.